### PR TITLE
chore: Add basic README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# lighthouse-jx-controller
+
+A controller for building and reporting on [Jenkins X pipelines](https://github.com/jenkins/jx) with [Lighthouse](https://github.com/jenkins-x/lighthouse).

--- a/bdd/lh-values.yaml.template
+++ b/bdd/lh-values.yaml.template
@@ -1,3 +1,8 @@
 # Disable the existing lighthouse-jx-controller in Lighthouse for the moment
 engines:
   jx: false
+
+# Specifying environment variable for link to build reports
+env:
+  JX_DEFAULT_IMAGE: ""
+  LIGHTHOUSE_REPORT_URL_BASE: "https://example.com"

--- a/charts/lighthouse-jx/templates/_helpers.tpl
+++ b/charts/lighthouse-jx/templates/_helpers.tpl
@@ -13,6 +13,6 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{- define "jxcontroller.name" -}}
-{{- $name := default "-controller" .Values.jxcontroller.nameOverride -}}
+{{- $name := default "controller" .Values.jxcontroller.nameOverride -}}
 {{- printf "%s-%s" .Chart.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/charts/lighthouse-jx/templates/jx-controller-deployment.yaml
+++ b/charts/lighthouse-jx/templates/jx-controller-deployment.yaml
@@ -40,7 +40,7 @@ spec:
             value: {{ quote $pval }}
 {{- end }}
 {{- end }}
-{{- with .Values.tektoncontroller.resources }}
+{{- with .Values.jxcontroller.resources }}
         resources:
 {{ toYaml . | indent 12 }}
 {{- end }}

--- a/cmd/jxcontroller/main.go
+++ b/cmd/jxcontroller/main.go
@@ -9,12 +9,12 @@ import (
 
 	jxclient "github.com/jenkins-x/jx-api/pkg/client/clientset/versioned"
 	jxinformers "github.com/jenkins-x/jx-api/pkg/client/informers/externalversions"
+	"github.com/jenkins-x/lighthouse-jx-controller/pkg/engines/jx"
 	clientset "github.com/jenkins-x/lighthouse/pkg/client/clientset/versioned"
 	lhinformers "github.com/jenkins-x/lighthouse/pkg/client/informers/externalversions"
 	"github.com/jenkins-x/lighthouse/pkg/clients"
 	"github.com/jenkins-x/lighthouse/pkg/interrupts"
 	"github.com/jenkins-x/lighthouse/pkg/logrusutil"
-	"github.com/jenkins-x/lighthouse-jx-controller/pkg/engines/jx"
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 )

--- a/pkg/engines/jx/activity_test.go
+++ b/pkg/engines/jx/activity_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 
 	v1 "github.com/jenkins-x/jx-api/pkg/apis/jenkins.io/v1"
+	"github.com/jenkins-x/lighthouse-jx-controller/pkg/engines/jx"
 	"github.com/jenkins-x/lighthouse/pkg/apis/lighthouse/v1alpha1"
 	"github.com/jenkins-x/lighthouse/pkg/util"
-	"github.com/jenkins-x/lighthouse-jx-controller/pkg/engines/jx"
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/yaml"
 )


### PR DESCRIPTION
Technically, this is also the first PR for us to test that the hacks (adding the new `lighthouse-jx` chart to the boot config's `env/requirements.yaml` so that the dang thing gets installed, while also disabling the `lighthouse-jx-controller` that Lighthouse itself would install right now) so I expect some things to go wrong.